### PR TITLE
[Design] Update Launch Screen (#65)

### DIFF
--- a/for.JOY/for-JOY-Info.plist
+++ b/for.JOY/for-JOY-Info.plist
@@ -6,6 +6,8 @@
 	<dict>
 		<key>UIImageName</key>
 		<string>LaunchScreen</string>
+		<key>UIColorName</key>
+		<string>forJoyBlack</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
## 📌 Summary
- 런치 스크린에 백그라운드 컬러 추가

## ✨ Description
- 현재 런치 스크린 이미지 사이즈가 아이폰14에 맞춰져 있음
- 이로 인해 아이폰14보다 큰 화면의 기기를 사용할 경우 여백이 생김
- 이를 해결하기 위해 백그라운드 컬러 추가
