### PR TITLE
[Fix] Update CarouselView (#67)

### DIFF
--- a/for.JOY/for.JOY/Views/CarouselView.swift
+++ b/for.JOY/for.JOY/Views/CarouselView.swift
@@ -159,6 +159,11 @@ extension CarouselView {
                             .padding(.trailing, 20)
                         }
                     }
+                    .onAppear {
+                        audioPlayerManager.isPlaying = false
+                        audioPlayerManager.isPaused = false
+                        audioPlayerManager.audioPlayer?.stop()
+                    }
                     .fullScreenCover(isPresented: $isShowEditSheet) {
                         EditInfoView(realmManager: realmManager, selectedData: memory)
                     }


### PR DESCRIPTION
## 📌 Summary
- 화면 이동 시 음성 재생 이슈 해결

## ✨ Description
- 캐로셀 뷰에서 탭을 이동하면 기존에 재생하던 음성이 정지하지 않고 계속 재생되는 이슈가 존재
- 탭이 onAppear될 때 음성 재생을 멈출 수 있도록 코드 추가
